### PR TITLE
Update vars in scripts to build additional target(s)

### DIFF
--- a/build_vars.sh
+++ b/build_vars.sh
@@ -6,7 +6,7 @@ set -o nounset
 set -o pipefail
 
 OPENWRT_VERSION=22.03.2
-DEFAULT_TARGETS="x86-generic ath79-generic ath79-nand ramips-mt76x8"
+DEFAULT_TARGETS="x86-generic ath79-generic ath79-nand ramips-mt76x8 ramips-mt7621"
 
 TARGETS="${TARGETS:-$DEFAULT_TARGETS}"
 CPUS=$(nproc)

--- a/build_vars.sh
+++ b/build_vars.sh
@@ -5,7 +5,7 @@ set -o nounset
 # show errors in pipes
 set -o pipefail
 
-OPENWRT_VERSION=22.03.2
+OPENWRT_VERSION=22.03
 DEFAULT_TARGETS="x86-generic ath79-generic ath79-nand ramips-mt76x8 ramips-mt7621"
 
 TARGETS="${TARGETS:-$DEFAULT_TARGETS}"


### PR DESCRIPTION
- Add new build target (ramips-mt7621, for example [Ubiquiti EdgeRouter X](https://openwrt.org/toh/ubiquiti/edgerouter_x_er-x_ka))
- Set OpenWrt version variable to match the [definition in gluon](https://github.com/Freifunk-Potsdam/gluon/blob/v2022.1.4-ffp-client-isolation/modules)

I'm unsure about the variable `OPENWRT_VERSION`. Should we set it to the current stable version (`22.03.5`)? Wher is the variable used and how? In the [OpenWrt repository](https://github.com/openwrt/openwrt/) are tags ([v22.03.5](https://github.com/openwrt/openwrt/tree/v22.03.5)) for releases and branches for the versions ([openwrt-22.03](https://github.com/openwrt/openwrt/tree/openwrt-22.03))

Build with ffp gluon branch [v2022.1.4-ffp-client-isolation](https://github.com/Freifunk-Potsdam/gluon/tree/v2022.1.4-ffp-client-isolation)
