### PR TITLE
Site Config Updates: 2023-08: Update Vars, Add Targets, Offline SSID Interval

### DIFF
--- a/build_starly.sh
+++ b/build_starly.sh
@@ -31,7 +31,18 @@ for T in $TARGETS; do
     fi
 done
 for BRANCH in stable early testing ; do
-    make manifest GLUON_RELEASE="$GLUON_RELEASE" GLUON_AUTOUPDATER_BRANCH="$BRANCH"
+    today=$( date +%Y-%m-%d )
+    in2w=$( date --date "2 weeks" +%Y-%m-%d )
+    in4w=$( date --date "4 weeks" +%Y-%m-%d )
+    if [ "$BRANCH" == "early" ]; then
+        make manifest GLUON_RELEASE="$GLUON_RELEASE" GLUON_AUTOUPDATER_BRANCH="$BRANCH" GLUON_PRIORITY="3"
+        sed -i "s/DATE=$today /DATE=$in2w /" output/images/sysupgrade/"${BRANCH}".manifest
+    elif [ "$BRANCH" == "stable" ]; then
+        make manifest GLUON_RELEASE="$GLUON_RELEASE" GLUON_AUTOUPDATER_BRANCH="$BRANCH" GLUON_PRIORITY="7"
+        sed -i "s/DATE=$today /DATE=$in4w /" output/images/sysupgrade/"${BRANCH}".manifest
+    else
+        make manifest GLUON_RELEASE="$GLUON_RELEASE" GLUON_AUTOUPDATER_BRANCH="$BRANCH" GLUON_PRIORITY="0"
+    fi
     if [ -f "$1" ]; then
         echo "Signing ${BRANCH}.manifest..."
         contrib/sign.sh "$1" output/images/sysupgrade/"${BRANCH}".manifest

--- a/build_vars.sh
+++ b/build_vars.sh
@@ -6,7 +6,7 @@ set -o nounset
 set -o pipefail
 
 OPENWRT_VERSION=22.03.2
-DEFAULT_TARGETS="x86-generic ath79-generic ath79-nand ramips-mt76x8"
+DEFAULT_TARGETS="x86-generic ath79-generic ath79-nand ramips-mt76x8 ramips-mt7621"
 
 TARGETS="${TARGETS:-$DEFAULT_TARGETS}"
 CPUS=$(nproc)

--- a/build_vars.sh
+++ b/build_vars.sh
@@ -5,7 +5,7 @@ set -o nounset
 # show errors in pipes
 set -o pipefail
 
-OPENWRT_VERSION=22.03.2
+OPENWRT_VERSION=22.03
 DEFAULT_TARGETS="x86-generic ath79-generic ath79-nand ramips-mt76x8 ramips-mt7621"
 
 TARGETS="${TARGETS:-$DEFAULT_TARGETS}"

--- a/site.conf
+++ b/site.conf
@@ -33,7 +33,7 @@
 
   ssid_changer = {
     enabled = true,
-    switch_timeframe = 60,    -- only once every timeframe (in minutes) the SSID will change to the Offline-SSID
+    switch_timeframe = 15,    -- only once every timeframe (in minutes) the SSID will change to the Offline-SSID
                               -- set to 1440 to change once a day
                               -- set to 1 minute to change every time the router gets offline
     first = 5,                -- the first few minutes directly after reboot within which an Offline-SSID always may be activated (must be <= switch_timeframe)

--- a/upload.sh
+++ b/upload.sh
@@ -3,6 +3,6 @@ cd `dirname $0`/..
 RELEASE=`head -n5 output/images/sysupgrade/*.manifest | tail -n1 | cut -d' ' -f2`
 
 if [ "$RELEASE" != "" ]; then
-    rsync -av --delete output/packages/gluon-ffp-${RELEASE}/ root@firmware.freifunk-potsdam.de:/docker/www/firmware/feed/gluon/core/gluon-ffp-${RELEASE}/
-    rsync -av --delete output/images/ root@firmware.freifunk-potsdam.de:/docker/www/firmware/gluon/$RELEASE/
+    rsync -av --delete output/packages/gluon-ffp-${RELEASE}/ root@daria.freifunk-potsdam.de:/data/www/firmware/feed/gluon/core/gluon-ffp-${RELEASE}/
+    rsync -av --delete output/images/ root@daria.freifunk-potsdam.de:/data/www/firmware/gluon/$RELEASE/
 fi


### PR DESCRIPTION
- Shortening Offline SSID interval to 15 minutes
- Manifest file updates
- Add new build target (ramips-mt7621, for example [Ubiquiti EdgeRouter X](https://openwrt.org/toh/ubiquiti/edgerouter_x_er-x_ka))
- Set OpenWrt version variable to match the [definition in gluon](https://github.com/Freifunk-Potsdam/gluon/blob/v2022.1.4-ffp-client-isolation/modules)

I'm unsure about the variable `OPENWRT_VERSION`. Should we set it to the current stable version (`22.03.5`)? Wher is the variable used and how? In the [OpenWrt repository](https://github.com/openwrt/openwrt/) are tags ([v22.03.5](https://github.com/openwrt/openwrt/tree/v22.03.5)) for releases and branches for the versions ([openwrt-22.03](https://github.com/openwrt/openwrt/tree/openwrt-22.03))

Build with ffp gluon branch [v2022.1.4-ffp-client-isolation](https://github.com/Freifunk-Potsdam/gluon/tree/v2022.1.4-ffp-client-isolation)
