### PR TITLE
Build Firmware based on Gluon 2023.2.4

### DIFF
--- a/build_vars.sh
+++ b/build_vars.sh
@@ -5,7 +5,7 @@ set -o nounset
 # show errors in pipes
 set -o pipefail
 
-OPENWRT_VERSION=23.05.2
+OPENWRT_VERSION=23.05.5
 DEFAULT_TARGETS="
     armsr-armv7
     armsr-armv8

--- a/domains/potsdam.conf
+++ b/domains/potsdam.conf
@@ -99,6 +99,10 @@
     ip6 = 'fdc0:ffee:0a10::ffff',
   },
 
+  radv_filterd = {
+    threshold = 20,
+  },
+
   mesh_vpn = {
     -- enabled = true,
     mtu = 1396,

--- a/domains/potsdam.conf
+++ b/domains/potsdam.conf
@@ -75,7 +75,6 @@
       routing_algo = 'BATMAN_IV',
       gw_sel_class = 1500,
     },
-    isolate = "no",
   },
 
   -- Use internal resolver

--- a/domains/potsdam_umland.conf
+++ b/domains/potsdam_umland.conf
@@ -73,7 +73,6 @@
       routing_algo = 'BATMAN_IV',
       gw_sel_class = 1500,
     },
-    isolate = "no",
   },
 
   -- Use internal resolver

--- a/domains/potsdam_umland.conf
+++ b/domains/potsdam_umland.conf
@@ -97,6 +97,10 @@
     ip6 = 'fdc0:ffee:0a10:10::ffff',
   },
 
+  radv_filterd = {
+    threshold = 20,
+  },
+
   mesh_vpn = {
     -- enabled = true,
     mtu = 1396,

--- a/image-customization.lua
+++ b/image-customization.lua
@@ -14,7 +14,6 @@ features({
     'config-mode-domain-select',
     'config-mode-geo-location-osm',
     'ffp-xmlcollect',
-    'client-isolation',
     'setup-mode-wifi',
     'wireless-encryption-wpa3',
     'private-wifi',

--- a/image-customization.lua
+++ b/image-customization.lua
@@ -20,6 +20,7 @@ features({
     'web-private-wifi',
     'mesh-wireless-sae',
     'mesh-vpn-sqm',
+    'radv-filterd',
 })
 
 -- Additional packages (was: GLUON_SITE_PACKAGES)

--- a/modules
+++ b/modules
@@ -2,7 +2,7 @@ GLUON_SITE_FEEDS='ffp_gluon_packages community'
 
 PACKAGES_FFP_GLUON_PACKAGES_REPO=https://github.com/Freifunk-Potsdam/gluon-ffp-packages.git
 PACKAGES_FFP_GLUON_PACKAGES_BRANCH=master
-PACKAGES_FFP_GLUON_PACKAGES_COMMIT=13db89fc294dfe516027fe77e2f8b59de641698c
+PACKAGES_FFP_GLUON_PACKAGES_COMMIT=4c5188d87f7fe8a600a3cd489b440b04c9603da2
 
 PACKAGES_COMMUNITY_REPO=https://github.com/freifunk-gluon/community-packages.git
 PACKAGES_COMMUNITY_BRANCH=master


### PR DESCRIPTION
- Remove client isolation (plugin)
- Add gluon-radv-filterd package (prefer next hop ipv6 gw)
- upgraded ffp-xmlcollect to include nodeid in header
- Update OpenWrt version (used for generic packages feed)
- Build is based on [v2023.2.4-ffp-client-isolation branch](https://github.com/Freifunk-Potsdam/gluon/tree/v2023.2.4-ffp-client-isolation) in [Freifunk-Potsdam/gluon](https://github.com/Freifunk-Potsdam/gluon)